### PR TITLE
Update test-go in .circleci/config.yml to upsize resource class from large to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     # Install go modules and run tests
     docker:
       - image: cimg/go:1.21.1
-    resource_class: x-large
+    resource_class: xlarge
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     # Install go modules and run tests
     docker:
       - image: cimg/go:1.21.1
-    resource_class: large
+    resource_class: x-large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Hi :wave: , we noticed that this job: `test-go` [has averaged > 80% CPU utilization in 70% of its last 6 runs](https://app.circleci.com/pipelines/circleci/688b194e-b9b7-4f5b-a1ba-9f3e97a74343/6dcc8a6e-f1dc-4f62-8503-21c35f4be855/3/workflows/f48a0fb1-9d11-4959-98b8-aeed2e8a3217/jobs/3/resources).

Merging this pull request will give you access to more CPU by upgrading the job’s resource class. Jobs on larger [resource classes](https://circleci.com/docs/configuration-reference/#resourceclass) **tend to run up to 50% faster :rocket:, minimizing the time you and your team spend waiting for changes to be validated.**

If this PR triggered a new run of the job, you can tell if the new resource class performs better if:

- the job runtime is shorter than the current median runtime from the past 2 weeks of 20.1 mins

- the job’s [CPU utilization](https://app.circleci.com/pipelines/circleci/688b194e-b9b7-4f5b-a1ba-9f3e97a74343/6dcc8a6e-f1dc-4f62-8503-21c35f4be855/3/workflows/f48a0fb1-9d11-4959-98b8-aeed2e8a3217/jobs/3/resources) is lower than the historic [CPU utilization](https://app.circleci.com/insights/circleci/688b194e-b9b7-4f5b-a1ba-9f3e97a74343/6dcc8a6e-f1dc-4f62-8503-21c35f4be855/workflows/build-and-test/jobs)

*Note*: This new resource class costs 20 credits/min; the current resource class costs 10 credits/min.

Questions about how this PR got created? See our [community forum](https://discuss.circleci.com/t/circleci-config-suggestions-bot/47918) for details.  Want to opt out of future config.yml suggestions? [Click here](https://docs.google.com/forms/d/1GG1iuIG4Ul98bZpjcj_xLZbnIzBYCmysMMPAs5tVpIg/edit).Happy building!